### PR TITLE
add .mikutter.yml

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -1,0 +1,10 @@
+---
+slug: :ahiru_yakuna
+depends:
+  mikutter: 3.0.6
+  plugin:
+  - activity
+version: 0.0.1
+author: "あひる"
+name: "あひる焼くなプラグイン"
+description: "あひる焼きを検出すると焼くなとリプする何か"


### PR DESCRIPTION
`mikuter` 3.0 or higher, .mikutter.yml is preferred instead of spec.
Because name conflict against rspec's spec directory naming rule.

ref: http://mikutter.blogspot.jp/2014/05/mikutter-30.html
